### PR TITLE
Changing extension initialization to MediaWiki practice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,34 @@
-wiki-seo
-========
 
-A simple MediaWiki extension to give you control over the html title and meta tags via a tag or parser function.
+# MediaWiki WikiSEO extension
 
-See http://www.mediawiki.org/wiki/Extension:WikiSEO
+This is a simple MediaWiki extension to give you control over the HTML title 
+and meta tags via a tag or parser function.
+
+## Steps to take
+
+### Download and install this extension
+
+You can get the extension via Git:
+
+    git clone https://github.com/andru/wiki-seo.git
+
+Or [download it as zip archive](https://github.com/andru/wiki-seo/archive/master.zip).
+
+In either case, the "WikiSEO" extension should end up in the "extensions" directory 
+of your MediaWiki installation. If you got the zip archive, you will need to put it 
+into a directory called WikiSEO.
+
+Add the following line to the end of your LocalSettings file:
+
+    require_once "$IP/extensions/WikiSEO/WikiSEO.php";
+
+Note that prior to version 1.1.1 of this extension the call was
+
+    require_once "$IP/extensions/WikiSEO/WikiSEO.setup.php";
+
+This is a lecacy call that will be dropped in a future version of this extension. 
+Because of this you are advised to change your current call to the new one.
+
+## Usage
+
+Use this extension as described [on the extensions documentation page](https://www.mediawiki.org/wiki/Extension:WikiSEO).

--- a/WikiSEO.php
+++ b/WikiSEO.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * WikiSEO extension - Allows per page meta settings (keywords, description) and to change the title.
+ * @version 1.1.1 - 2013/12/02 (based on the work of Vladimir Radulovski and Jim Wilson)
+ *
+ * @link https://www.mediawiki.org/wiki/Extension:WikiSEO Documentation
+ * @link https://www.mediawiki.org/wiki/Extension_talk:WikiSEO Support
+ * @link https://github.com/andru/wiki-seo Source Code
+ *
+ * @file
+ * @ingroup Extensions
+ * @package MediaWiki
+ * @author Andru Vallance (Andrujhon)
+ * @copyright (C) 2013 Andru Vallance
+ * @license http://www.gnu.org/copyleft/gpl.html GNU General Public License 2.0 or later
+ */
+
+// Confirm MW environment
+if ( !defined( 'MEDIAWIKI' ) ) {
+	die( 'This file is a MediaWiki extension and thus not a valid entry point.' );
+}
+
+// Credits
+$wgExtensionCredits['parserhook'][] = array(
+	'path' => __FILE__,
+	'name' => 'WikiSEO',
+	'author' => array(
+		'Andru Vallance', '...'
+		),
+	'url' =>'https://www.mediawiki.org/wiki/Extension:WikiSEO',
+	'descriptionmsg' => 'seo-desc',
+	'version'=>'1.1.1'
+);
+
+$wgAutoloadClasses['WikiSEO'] = dirname(__FILE__) . '/WikiSEO.body.php';
+$wgExtensionMessagesFiles['WikiSEOMagic'] = dirname( __FILE__ ) . '/WikiSEO.i18n.magic.php';
+$wgExtensionMessagesFiles['WikiSEO'] = dirname( __FILE__ ) . '/WikiSEO.i18n.php';
+
+//init the parser function & tag extension
+$wgHooks['ParserFirstCallInit'][] = 'WikiSEO::init';
+//check the wikitext for cached values
+$wgHooks['OutputPageBeforeHTML'][] = 'WikiSEO::loadParamsFromWikitext';
+//$wgHooks['OutputPageBeforeHTML'][] = 'WikiSEO::modifyHTML';
+
+//set the tags
+$wgHooks['BeforePageDisplay'][] = 'WikiSEO::modifyHTML';

--- a/WikiSEO.setup.php
+++ b/WikiSEO.setup.php
@@ -1,8 +1,7 @@
 <?php
-
 /**
- * WikiSEO extension - Allows per page meta settings (keywords, description) and to change the title.
- * @version 1.0.1 - 2013/07/12 (based on the work of Vladimir Radulovski and Jim Wilson)
+ * Legacy Initialization file
+ * @since 1.1.1
  *
  * @link https://www.mediawiki.org/wiki/Extension:WikiSEO Documentation
  *
@@ -10,36 +9,13 @@
  * @ingroup Extensions
  * @package MediaWiki
  * @author Andru Vallance (Andrujhon)
+ * @author Karsten Hoffmeyer (Kghbln)
  * @copyright (C) 2013 Andru Vallance
  * @license http://www.gnu.org/copyleft/gpl.html GNU General Public License 2.0 or later
  */
 
-# Confirm MW environment
 if ( !defined( 'MEDIAWIKI' ) ) {
-	die( 'This file is a MediaWiki extension and thus not a valid entry point' );
+   die( 'This file is a MediaWiki extension and thus not a valid entry point.' );
 }
 
-# Credits
-$wgExtensionCredits['parserhook'][] = array(
-	'path' => __FILE__,
-	'name' => 'WikiSEO',
-	'author' => array(
-		'Andru Vallance', '...'
-		),
-	'url' =>'https://www.mediawiki.org/wiki/Extension:WikiSEO',
-	'descriptionmsg' => 'seo-desc',
-	'version'=>'1.0.1'
-);
-
-$wgAutoloadClasses['WikiSEO'] = dirname(__FILE__) . '/WikiSEO.body.php';
-$wgExtensionMessagesFiles['WikiSEOMagic'] = dirname( __FILE__ ) . '/WikiSEO.i18n.magic.php';
-$wgExtensionMessagesFiles['WikiSEO'] = dirname( __FILE__ ) . '/WikiSEO.i18n.php';
-
-//init the parser function & tag extension
-$wgHooks['ParserFirstCallInit'][] = 'WikiSEO::init';
-//check the wikitext for cached values
-$wgHooks['OutputPageBeforeHTML'][] = 'WikiSEO::loadParamsFromWikitext';
-//$wgHooks['OutputPageBeforeHTML'][] = 'WikiSEO::modifyHTML';
-
-//set the tags
-$wgHooks['BeforePageDisplay'][] = 'WikiSEO::modifyHTML';
+include 'WikiSEO.php';


### PR DESCRIPTION
This commit includes the following changes':
- Add WikiSEO.php to conform with MediaWiki practice
- Makes WikiSEO.setup.php a legacy initialization file
- Expands the README
- Increments the version
