### PR TITLE
Set "manifest_version" to 1

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -32,5 +32,6 @@
 		"FacebookAdmins": [],
 		"FacebookAppID": "",
 		"AddJSONLD": true
-	}
+	},
+	"manifest_version": 1
 }


### PR DESCRIPTION
It's deprecated now to not manifest_version have set in extension.json

" Use of WikiSEO's extension.json or skin.json does not have manifest_version was deprecated in MediaWiki 1.29. [Called from ExtensionRegistry::loadFromQueue in /srv/mediawiki/w/includes/registration/ExtensionRegistry.php at line 161]"