### PR TITLE
jsonLD: remove trailing comma from description

### DIFF
--- a/WikiSEO.body.php
+++ b/WikiSEO.body.php
@@ -336,7 +336,7 @@ class WikiSEO{
 					$out->addMeta( $name, $content );
 					$out->addMeta( "twitter:description", $content );
 					$out->addHeadItem("og:description", Html::element( 'meta', array( 'property' => 'og:description', 'content' => $content ) ));
-					$jsonLD .= '"description":"'.$content.'",';
+					$jsonLD .= '"description":"'.$content.'"';
 				} else {
 					$out->addMeta( $name, $content );
 				}


### PR DESCRIPTION
This comma seems out of place. The jsonLD concatenations following all prefix with a comma, so this would generate two in that case, and when there's even just one, Google Websearch Console complains about "unparseable structured data". This change fixes that.